### PR TITLE
replace the background-cover imgUri to cdn resource

### DIFF
--- a/source/css/uno.css
+++ b/source/css/uno.css
@@ -1196,7 +1196,7 @@ hr {
   width: 100%;
   max-width: none;
   height: 100%;
-  background: url(../images/background-cover.jpg) top left no-repeat #666666;
+  background: url("//img.alicdn.com/tps/TB1UC8nJVXXXXbRXpXXXXXXXXXX-1920-1200.jpg") top left no-repeat #666666;
   background-size: cover; }
 
 .panel-cover--collapsed {
@@ -1677,7 +1677,7 @@ table {
   border-collapse: collapse;
   width: 100%;
   margin: 0 0 10px;
-  border-spacing: 0; 
+  border-spacing: 0;
   border: 1px solid #aaa;
 }
 
@@ -1699,5 +1699,5 @@ th, td {
   border: none;
 }
 pre {
-  font-family: 
+  font-family:
 }


### PR DESCRIPTION
The background img size if  712KB and took up a lot  dataflow for a personal blog. So replace the background-cover imgUri to cdn resource.